### PR TITLE
Initialize errorMessage with minimum size.

### DIFF
--- a/test/include/GLUtils/GLUtils.cpp
+++ b/test/include/GLUtils/GLUtils.cpp
@@ -43,7 +43,7 @@ void GLUtils::loadShader(char* shaderSource, GLenum shaderType, GLuint &programI
     // Check shader
     glGetShaderiv(shaderId, GL_COMPILE_STATUS, &result);
     glGetShaderiv(shaderId, GL_INFO_LOG_LENGTH, &infoLogLength);
-    std::vector<char> errorMessage(infoLogLength);
+    std::vector<char> errorMessage(std::max(infoLogLength, int(1)));
     glGetShaderInfoLog(shaderId, infoLogLength, NULL, &errorMessage[0]);
     fprintf(stdout, "%s\n", &errorMessage[0]);
 


### PR DESCRIPTION
When I first ran the program I got a vector subscript out of range error while getting the shader info log, so I followed the same convention as programErrorMessage to resolve the risk.